### PR TITLE
Add quotes around a command path to fix a bug on Windows

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -10,7 +10,7 @@ const main = async () => {
   const args = ['configure', 'rebuild'];
 
   await new Promise((resolve, reject) => {
-    const spawnedProc = spawn(nodeGypPath, args, {stdio: 'inherit', shell: true})
+    const spawnedProc = spawn(`"${nodeGypPath}" ${args.join(' ')}`, { stdio: 'inherit', shell: true });
 
     spawnedProc.on('close', (code) => {
       if (code === 0) {


### PR DESCRIPTION
Add quotes around a command path to fix a bug when using on Windows in a directory with a space. Without the quotes, the command is split at the space, causing errors. 