### PR TITLE
fix: update tar 7.5.9 to 7.5.10 to resolve path traversal vulnerability

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -587,9 +587,9 @@ strip-ansi@^7.0.1:
     ansi-regex "^6.0.1"
 
 tar@^7.4.3:
-  version "7.5.9"
-  resolved "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz#817ac12a54bc4362c51340875b8985d7dc9724b8"
-  integrity sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==
+  version "7.5.10"
+  resolved "https://registry.npmjs.org/tar/-/tar-7.5.10.tgz#2281541123f5507db38bc6eb22619f4bbaef73ad"
+  integrity sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==
   dependencies:
     "@isaacs/fs-minipass" "^4.0.0"
     chownr "^3.0.0"


### PR DESCRIPTION
## Summary
- Update `tar` 7.5.9 → 7.5.10 in yarn.lock to fix Hardlink Path Traversal via Drive-Relative Linkpath (Dependabot alert #30)
- Lockfile-only change — `node-gyp` depends on `tar ^7.4.3`, so 7.5.10 is within the existing semver range

## Test plan
- [x] `yarn install` succeeds
- [x] Native addon compiles successfully
- [x] Module loads and exports correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)