### PR TITLE
Fix brace-expansion and picomatch dependency vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,9 @@
   "dependencies": {
     "node-addon-api": "^8.0.0",
     "node-gyp": "^11.0.0"
+  },
+  "resolutions": {
+    "brace-expansion": "^2.0.3",
+    "picomatch": ">=4.0.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,13 +80,13 @@ ansi-styles@^6.1.0:
 
 balanced-match@^1.0.0:
   version "1.0.2"
-  resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-brace-expansion@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz#54fc53237a613d854c7bd37463aad17df87214e7"
-  integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
+brace-expansion@^2.0.2, brace-expansion@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.3.tgz#0493338bdd58e319b1039c67cf7ee439892c01d9"
+  integrity sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==
   dependencies:
     balanced-match "^1.0.0"
 
@@ -452,10 +452,10 @@ path-scurry@^1.11.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
-picomatch@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
-  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
+picomatch@>=4.0.4, picomatch@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
 proc-log@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Summary
- Add yarn `resolutions` to force patched versions of vulnerable transitive dependencies
- `brace-expansion` 2.0.2 → 2.0.3 — fixes GHSA-f886-m6hf-6m8v (zero-step sequence causes process hang and memory exhaustion)
- `picomatch` 4.0.3 → 4.0.4 — fixes GHSA-c2c7-rcm5-vvqj (ReDoS via extglob quantifiers) and GHSA-3v7f-55p6-f55p (method injection in POSIX character classes)
- Resolves Dependabot alerts 32, 33, and 35

## Test plan
- [ ] Verify `yarn list --pattern brace-expansion` shows 2.0.3
- [ ] Verify `yarn list --pattern picomatch` shows 4.0.4
- [ ] Verify `yarn install` completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)